### PR TITLE
invitation and playpen rendering

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -38,19 +38,29 @@ export class App extends Component {
     console.log('SNAPSHOT', snapshot.data())
   };
 
+//want their invitation to show up regardless of what stage they are in
+//want it to pop up on top of everything else
+//once they accept in a playpen, want the intervals to clear, and they set a new work/break interval for the playpen that applies to everyone
+//want it to show their current health but be on the same timer now
+//
+
   render() {
+    console.log("invited??", this.props.avatar.invited)
     return (
       <div>
         <div className="navbar">
           {!this.props.loggedIn 
-            ? <div><Login /> <Donke /></div>
+            ? <div> <Login /> <Donke /></div>
             : !this.props.avatar.name 
               ? <div> <NewBuddy /> <Donke /> </div>
-              :  <div className="animal">
-                <Navbar /> <SelectDonke />
+              : this.props.inPlaypen
+                ? <div> <Navbar/> <Playpen /> </div>
+                : <div> <Navbar /> <SelectDonke />
+                  {this.props.avatar.invited
+                  ? <div> <Invitation /></div>
+                  : null}
               </div> }
         </div>
-        {/*<Invitation/>*/}
       </div>
     )
   }
@@ -59,7 +69,9 @@ export class App extends Component {
 const mapStateToProps = state => {
   return {
     loggedIn: state.loggedIn,
-    avatar: state.avatar
+    avatar: state.avatar,
+    workInterval: state.workInterval,
+    inPlaypen: state.playpenStatus
   }
 }
 

--- a/client/components/NewBuddy.js
+++ b/client/components/NewBuddy.js
@@ -20,14 +20,13 @@ export class NewBuddy extends Component {
   }
 
   handleNameBuddy(event) {
-    console.log('got inside handlenamebuddy')
     event.preventDefault
     createAvatarFirebase({
       name: this.state.buddyName,
       userId: auth.currentUser.uid,
       health: 10,
       playpenId: null,
-      invited: false
+      invited: true
     })
   }
 

--- a/client/components/invitation.js
+++ b/client/components/invitation.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import * as firebase from 'firebase'
 import { db, auth, authAdmin } from '../app'
-import store, { setPlaypenStatus } from '../store'
+import store, { setPlaypenStatus, setInvited } from '../store'
 
 
 export class Invitation extends Component {
@@ -11,35 +11,33 @@ export class Invitation extends Component {
         this.state = {
             user: "Butt",
             playpenName: "Butt's Playpen",
-            invited: true
         }
         this.handleClickYes = this.handleClickYes.bind(this)
         this.handleClickNo = this.handleClickNo.bind(this)
     }
     handleClickYes(){
+        console.log('in handle click yes')
         this.props.setPlaypen(true)
-        this.setState({invited: false})
+        this.props.setStoreInvited(false)
         //render playpen
         //toggle invited to false
         //db.collections("avatar").doc(avatarId).update({invited: false})
     }
     handleClickNo(){
-        this.setState({ invited: false })
+        console.log('in handle click no')
+        this.props.setStoreInvited(false)
         //close window -- toggle invited to false and playpen id to null which should return normal view
         //db.collections("avatar").doc(avatarId).update({invited: false, playpenId: null})
     }
 
     render(){
         return (
-            <div>
-            {this.state.invited
-                ? <div> 
-                    <p>{this.state.user} has invited you to join them in {this.state.playpenName}! Would you like to join this playpen?</p>
+            <div className='navbarForm navbar-container navbar-wrapper' id='invitation'>
+                <p>{this.state.user} has invited you to join them in {this.state.playpenName}! Would you like to join this playpen?</p>
+                <div id="invitation-btns">
                     <button onClick={this.handleClickYes}>Yes</button>
                     <button onClick={this.handleClickNo}>No</button> 
                 </div>
-                : null
-            }
             </div>
         )
     }
@@ -47,7 +45,7 @@ export class Invitation extends Component {
 
 const mapStateToProps = state => {
     return {
-        inPlaypen: state.playpenStatus
+        avatar: state.avatar
     }  
 }
 
@@ -56,6 +54,9 @@ const mapDispatchToProps = dispatch => {
         setPlaypen(bool) {
             dispatch(setPlaypenStatus(bool))
         },
+        setStoreInvited(bool) {
+            dispatch(setInvited(bool))
+        }
     }
 }
 

--- a/client/components/playpen.js
+++ b/client/components/playpen.js
@@ -5,6 +5,9 @@ import store, { setPlaypenStatus } from '../store';
 
 // var currentuser = firebase.auth().currentUser;
 
+//delete playpen once everyone leaves
+//keep track of who has accepted or not?
+
 export class Playpen extends Component {
   constructor(props) {
     super(props);
@@ -17,14 +20,16 @@ export class Playpen extends Component {
 
   leavePlaypen(){
     this.props.setPlaypen(false)
+    //add logic to update firebase
   }
 
   //render donkes -- avatars.forEach... render donkes according to health
   render() {
     return (
       <div>
-        <button onClick={this.leavePlaypen}>X</button>
-        <h1>HELLO DONKE</h1>
+        <button className='donkeBtn' onClick={this.leavePlaypen}>Leave Playpen</button>
+        <p>In a playpen!</p>
+        <img id="donke" src={`../img/donke${this.props.health}.svg`} onClick={() => playAudio('happy')} />
       </div>
     );
   }

--- a/client/components/selectDonke.js
+++ b/client/components/selectDonke.js
@@ -4,12 +4,6 @@ import { connect } from 'react-redux';
 import { playAudio } from '../library/audio';
 import store, { fetchHealth, fetchWorkInterval, fetchBreakInterval, fetchStatus, deleteAvatarFirebase, setStart } from '../store';
 
-
-//need to init cloud function so can add user to database immediately after auth
-//
-//make keys un-secret
-
-
 //create timer variables so can assign them in order to clear them
 let timerFunc;
 let healthFunc;
@@ -130,20 +124,17 @@ export class SelectDonke extends Component {
   }
 
   render() {
-    // console.log('THIS IS THE WORKINTERVAL', this.props.workInterval)
+    console.log("in playpen? ", this.props.inPlaypen)
     return (
       this.props.workInterval > 0
         //if the user has submitted their work/break intervals render the below
-        ? this.props.inPlaypen
-          //render playpen if they are in a playpen
-          ? <Playpen/>
-          : this.props.status !== 'break'
+        ? this.props.status !== 'break'
             //render the below if they are not on a break
             ? <div> 
               {this.props.health > 0
                 //render "Take a break" button if they have health or "Try again" button if they don't
-                ? <button id="donkeBtn" onClick={this.handleClickBreak}>Take a break!</button>
-                : <button id="donkeBtn" onClick={this.handleClickTryAgain}>Try Again</button>}
+                ? <button className="donkeBtn" onClick={this.handleClickBreak}>Take a break!</button>
+                : <button className="donkeBtn" onClick={this.handleClickTryAgain}>Try Again</button>}
                 <Donke />
                 {this.props.health === 10 
                   ? this.props.status === 'needBreak' 
@@ -206,7 +197,7 @@ export class SelectDonke extends Component {
                 {this.props.health === 0 ? <div><Halo /><Cloud /><Lightning/></div> : null}
               </div>
             : this.state.breakTimeOver
-              ? <div> <button id="donkeBtn" onClick={this.handleClickWork}>Work time!</button> <SleepingDonke /> </div>
+              ? <div> <button className="donkeBtn" onClick={this.handleClickWork}>Work time!</button> <SleepingDonke /> </div>
               : <div><SleepingDonke/></div>
         //if the user has not submitted time specifications, just render happy donke
         : <div><Donke /></div>
@@ -222,7 +213,6 @@ const mapStateToProps = state => {
     health: state.health,
     idleTime: state.idleTime,
     status: state.status,
-    inPlaypen: state.playpenStatus,
     avatar: state.avatar
   }
 }

--- a/client/store/avatar.js
+++ b/client/store/avatar.js
@@ -8,6 +8,8 @@ const CREATE_AVATAR = 'CREATE_AVATAR'
 
 const DELETE_AVATAR = 'DELETE_AVATAR'
 
+const SET_INVITED = 'SET_INVITED'
+
 /**
  * INITIAL STATE
  */
@@ -27,6 +29,8 @@ const defaultAvatar = {
 const createAvatar = (avatar) => ({ type: CREATE_AVATAR, avatar })
 
 const deleteAvatar = () => ({ type: DELETE_AVATAR })
+
+export const setInvited = (bool) => ({ type: SET_INVITED, bool })
 
 /**
  * FIRESTORE + LOCAL STORE UPDATERS
@@ -58,8 +62,10 @@ export default function (state = defaultAvatar, action) {
   switch (action.type) {
     case CREATE_AVATAR:
       return action.avatar;
-     case DELETE_AVATAR: 
-   	  return defaultAvatar;
+    case DELETE_AVATAR: 
+      return defaultAvatar;
+    case SET_INVITED:
+      return Object.assign({}, state, {invited: action.bool});
     default:
       return state;
   }

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ app.on('ready', function () {
     slashes: true
   }));
 
-  // mainWindow.openDevTools();
+  mainWindow.openDevTools();
 
   mainWindow.on('closed', function () {
     mainWindow = null;

--- a/public/style.css
+++ b/public/style.css
@@ -91,7 +91,6 @@ select {
   margin: auto auto 2px auto;
   flex-direction: column;
   justify-content: center;
-  /* z-index: 1; */
 }
 
 .navbar-wrapper button {
@@ -125,7 +124,7 @@ select {
 
 
 /********************** DONKE BUTTON *********************/
-#donkeBtn {
+.donkeBtn {
   position: absolute;
   left: 20px;
   top: 100px;
@@ -142,9 +141,10 @@ select {
   border-radius: 10px;
   font-family: 'Pangolin';
   transition-duration: 0.4s;
+  z-index: 9;
 }
 
-#donkeBtn:hover{
+.donkeBtn:hover{
   background-color: #87CEEB;
   color: white;
 }
@@ -409,6 +409,22 @@ select {
   margin: 5px auto auto auto;
 }
 
+/********************** INVITATION *********************/
+
+#invitation {
+  border: 1px solid gray;
+}
+
+#invitation p {
+  padding: 0 1em;
+}
+
+#invitation-btns {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    padding-bottom: 1em;
+}
 /********************** PLAYPEN *********************/
 
 .playpen-container {


### PR DESCRIPTION
Hey guys! some things to note -- when a new avatar is created the default for invited is set to "true" right now (in component NewBuddy). feel free to change this, i had it in there so i could render the invitation form.

For some reason the invitation form is rendering behind the animations and I can't figure out why! I used the existing css for navbar wrapper, container, form so the z-index is set to 10. I would love someone else's eyes on this.

When you click "yes" to the invitation, it takes you into a playpen where your donkey is rendered with it's current health. I set it up so the Playpen component is rendered instead of the SelectDonke component (we want the SelectDonke component to unmount so that any running timers are cleared).

When you click "leave playpen" it takes you back into SelectDonke. All this logic (when to show the invitation, when to render SelectDonke vs Playpen) is set up in our app.js using props from the store.

I feel like I've gotten as far as I can without connecting it to firebase, so I'm going to leave it here for now. 